### PR TITLE
fix: stop importing `preact-render-to-string` via a bare specifier

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
     "$fresh-testing-library": "./mod.ts",
     "$fresh-testing-library/": "./",
     "$gfm": "https://deno.land/x/gfm@0.2.5/mod.ts",
-    "TODO(#58)": "The folloing line should be remove once fresh@v1.5.3 is released.",
+    "!TODO(#58)": "The following line should be remove once fresh@v1.5.3 is released.",
     "preact-render-to-string": "./deps/preact-render-to-string.ts"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },

--- a/deno.json
+++ b/deno.json
@@ -27,7 +27,9 @@
     "🔧/": "./demo/services/",
     "$fresh-testing-library": "./mod.ts",
     "$fresh-testing-library/": "./",
-    "$gfm": "https://deno.land/x/gfm@0.2.5/mod.ts"
+    "$gfm": "https://deno.land/x/gfm@0.2.5/mod.ts",
+    "TODO(#58)": "The folloing line should be remove once fresh@v1.5.3 is released.",
+    "preact-render-to-string": "./deps/preact-render-to-string.ts"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
   "lint": { "rules": { "tags": ["fresh", "recommended"] } }

--- a/deno.json
+++ b/deno.json
@@ -28,8 +28,8 @@
     "$fresh-testing-library": "./mod.ts",
     "$fresh-testing-library/": "./",
     "$gfm": "https://deno.land/x/gfm@0.2.5/mod.ts",
-    "!TODO(#58)": "The following line should be remove once fresh@v1.5.3 is released.",
-    "preact-render-to-string": "./deps/preact-render-to-string.ts"
+    "__TODO(#58)__": "The following line should be removed once fresh@v1.5.3 is released.",
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.2"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
   "lint": { "rules": { "tags": ["fresh", "recommended"] } }

--- a/deno.json
+++ b/deno.json
@@ -15,7 +15,6 @@
     "$fresh/": "https://deno.land/x/fresh@1.5.1/",
     "preact": "https://esm.sh/preact@10.18.1",
     "preact/": "https://esm.sh/preact@10.18.1/",
-    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.2",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.2.1",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.0",
     "twind": "https://esm.sh/twind@0.16.19",

--- a/deps/preact-render-to-string.ts
+++ b/deps/preact-render-to-string.ts
@@ -1,0 +1,9 @@
+/**
+ * The version of `preact-render-to-string` should match what is loaded in [src/server/deps.ts](https://github.com/denoland/fresh/blob/main/src/server/deps.ts).
+ *
+ * TODO(uki00a): I'd like to automate the synchronization of `preact-render-to-string` versions.
+ *
+ * {@link https://github.com/denoland/fresh/pull/1684}
+ * {@link https://github.com/denoland/fresh/blob/5de34aac93a0090d85d6cd449c413b97a98f018e/src/server/deps.ts#L23}
+ */
+export { renderToString } from "https://esm.sh/*preact-render-to-string@6.2.2";

--- a/deps/preact-render-to-string.ts
+++ b/deps/preact-render-to-string.ts
@@ -6,4 +6,4 @@
  * {@link https://github.com/denoland/fresh/pull/1684}
  * {@link https://github.com/denoland/fresh/blob/5de34aac93a0090d85d6cd449c413b97a98f018e/src/server/deps.ts#L23}
  */
-export { renderToString } from "https://esm.sh/*preact-render-to-string@6.2.2";
+export { render } from "https://esm.sh/*preact-render-to-string@6.2.2";

--- a/internal/fresh/mod.ts
+++ b/internal/fresh/mod.ts
@@ -1,7 +1,7 @@
 import { extname } from "node:path";
 import type { ClassAttributes, VNode } from "preact";
 import { h } from "preact";
-import { render } from "preact-render-to-string";
+import { render } from "../../deps/preact-render-to-string.ts";
 import type {
   Manifest,
   MiddlewareHandler,

--- a/tools/check_imports.ts
+++ b/tools/check_imports.ts
@@ -51,6 +51,7 @@ async function checkImports(): Promise<void> {
   }
 }
 
+const acceptableBareSpecifiers = ["preact"];
 function isAllowedSpecifier(specifier: string, referrer: string): boolean {
   if (
     specifier.startsWith("npm:") || specifier.startsWith("node:")
@@ -77,7 +78,7 @@ function isAllowedSpecifier(specifier: string, referrer: string): boolean {
 
   // Bare specifiers
   return specifier.startsWith("$fresh/") ||
-    specifier === "preact-render-to-string" || specifier === "preact";
+    acceptableBareSpecifiers.includes(specifier);
 }
 
 function isRelative(specifier: string): boolean {

--- a/tools/check_imports.ts
+++ b/tools/check_imports.ts
@@ -61,7 +61,16 @@ function isAllowedSpecifier(specifier: string, referrer: string): boolean {
 
   if (URL.canParse(specifier)) {
     const url = new URL(specifier);
-    return url.hostname !== "esm.sh" || url.searchParams.has("pin");
+    if (url.hostname !== "esm.sh") {
+      return true;
+    }
+
+    if (url.pathname.startsWith("/*preact-render-to-string@")) {
+      // NOTE: `preact-render-to-string` should not be pinned.
+      return true;
+    }
+
+    return url.searchParams.has("pin");
   }
 
   if (isAbsolute(specifier)) {


### PR DESCRIPTION
Fresh has been changed to not import `preact-render-to-string` via a bare specifier (https://github.com/denoland/fresh/pull/1684). This module should also stop doing so.

Closes #57