### PR TITLE
feat(server): add `createFreshContext`, deprecate `createHandlerContext` and `createMiddlewareHandlerContext`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 .vscode
 .doctest.ts
+.doctest.tsx
 
 # Fresh build directory
 _fresh/

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Deno.test("expect", () => {
 
 ### Testing fresh middlewares
 
-You can test fresh middlewares using `createMiddlewareHandlerContext` API:
+You can test fresh middlewares using `createFreshContext()` API:
 
 ```ts
-import { createMiddlewareHandlerContext } from "$fresh-testing-library/server.ts";
+import { createFreshContext } from "$fresh-testing-library/server.ts";
 import { assert } from "$std/assert/assert.ts";
 import { assertEquals } from "$std/assert/assert_equals.ts";
 import { describe, it } from "$std/testing/bdd.ts";
@@ -122,7 +122,7 @@ describe("createLoggerMiddleware", () => {
     const middleware = createLoggerMiddleware(testingLogger);
     const path = `/api/users/123`;
     const req = new Request(`http://localhost:3000${path}`);
-    const ctx = createMiddlewareHandlerContext(req, { manifest });
+    const ctx = createFreshContext(req, { manifest });
     await middleware(req, ctx);
     assertEquals(messages, [
       `<-- GET ${path}`,
@@ -134,10 +134,10 @@ describe("createLoggerMiddleware", () => {
 
 ### Testing fresh handlers
 
-You can test fresh handlers using `createHandlerContext` API:
+You can also test fresh handlers using `createFreshContext()` API:
 
 ```ts
-import { createHandlerContext } from "$fresh-testing-library/server.ts";
+import { createFreshContext } from "$fresh-testing-library/server.ts";
 
 import { assert } from "$std/assert/assert.ts";
 import { assertEquals } from "$std/assert/assert_equals.ts";
@@ -151,7 +151,7 @@ describe("handler.GET", () => {
     assert(handler.GET);
 
     const req = new Request("http://localhost:8000/api/users/1");
-    const ctx = createHandlerContext(req, { manifest });
+    const ctx = createFreshContext(req, { manifest });
     assertEquals(ctx.params, { id: "1" });
 
     const res = await handler.GET(req, ctx);
@@ -163,7 +163,7 @@ describe("handler.GET", () => {
 
 ### Testing async route components
 
-You can test async route components by combining `createRouteContext()` and
+You can test async route components by combining `createFreshContext()` and
 `render()`:
 
 ```ts
@@ -173,7 +173,7 @@ import {
   render,
   setup,
 } from "$fresh-testing-library/components.ts";
-import { createRouteContext } from "$fresh-testing-library/server.ts";
+import { createFreshContext } from "$fresh-testing-library/server.ts";
 import { assertExists } from "$std/assert/assert_exists.ts";
 import { afterEach, beforeAll, describe, it } from "$std/testing/bdd.ts";
 import { default as UserDetail } from "./demo/routes/users/[id].tsx";
@@ -187,7 +187,7 @@ describe("routes/users/[id].tsx", () => {
   it("should work", async () => {
     const req = new Request("http://localhost:8000/users/2");
     const state = { users: createInMemoryUsers() };
-    const ctx = createRouteContext<void, typeof state>(req, {
+    const ctx = createFreshContext<void, typeof state>(req, {
       manifest,
       // It is possible to inject dependencies into `ctx.state` with `state` option.
       state,
@@ -205,7 +205,7 @@ This library provides submodules so that only necessary functions can be
 imported.
 
 ```ts
-import { createHandlerContext } from "$fresh-testing-library/server.ts";
+import { createFreshContext } from "$fresh-testing-library/server.ts";
 
 import {
   cleanup,

--- a/demo/fresh.gen.ts
+++ b/demo/fresh.gen.ts
@@ -2,37 +2,38 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $0 from "./routes/(admin)/dashboard.tsx";
-import * as $1 from "./routes/_app.tsx";
-import * as $2 from "./routes/_middleware.ts";
-import * as $3 from "./routes/api/users/[id].ts";
-import * as $4 from "./routes/docs/[...path].tsx";
-import * as $5 from "./routes/docs/_layout.tsx";
-import * as $6 from "./routes/index.tsx";
-import * as $7 from "./routes/users/[id].tsx";
-import * as $8 from "./routes/users/_layout.tsx";
-import * as $9 from "./routes/users/_middleware.ts";
-import * as $10 from "./routes/users/index.tsx";
-import * as $$0 from "./islands/Counter.tsx";
+import * as $_admin_dashboard from "./routes/(admin)/dashboard.tsx";
+import * as $_app from "./routes/_app.tsx";
+import * as $_middleware from "./routes/_middleware.ts";
+import * as $api_users_id_ from "./routes/api/users/[id].ts";
+import * as $docs_path_ from "./routes/docs/[...path].tsx";
+import * as $docs_layout from "./routes/docs/_layout.tsx";
+import * as $index from "./routes/index.tsx";
+import * as $users_id_ from "./routes/users/[id].tsx";
+import * as $users_layout from "./routes/users/_layout.tsx";
+import * as $users_middleware from "./routes/users/_middleware.ts";
+import * as $users_index from "./routes/users/index.tsx";
+import * as $Counter from "./islands/Counter.tsx";
+import { type Manifest } from "$fresh/server.ts";
 
 const manifest = {
   routes: {
-    "./routes/(admin)/dashboard.tsx": $0,
-    "./routes/_app.tsx": $1,
-    "./routes/_middleware.ts": $2,
-    "./routes/api/users/[id].ts": $3,
-    "./routes/docs/[...path].tsx": $4,
-    "./routes/docs/_layout.tsx": $5,
-    "./routes/index.tsx": $6,
-    "./routes/users/[id].tsx": $7,
-    "./routes/users/_layout.tsx": $8,
-    "./routes/users/_middleware.ts": $9,
-    "./routes/users/index.tsx": $10,
+    "./routes/(admin)/dashboard.tsx": $_admin_dashboard,
+    "./routes/_app.tsx": $_app,
+    "./routes/_middleware.ts": $_middleware,
+    "./routes/api/users/[id].ts": $api_users_id_,
+    "./routes/docs/[...path].tsx": $docs_path_,
+    "./routes/docs/_layout.tsx": $docs_layout,
+    "./routes/index.tsx": $index,
+    "./routes/users/[id].tsx": $users_id_,
+    "./routes/users/_layout.tsx": $users_layout,
+    "./routes/users/_middleware.ts": $users_middleware,
+    "./routes/users/index.tsx": $users_index,
   },
   islands: {
-    "./islands/Counter.tsx": $$0,
+    "./islands/Counter.tsx": $Counter,
   },
   baseUrl: import.meta.url,
-};
+} satisfies Manifest;
 
 export default manifest;

--- a/demo/routes/(admin)/dashboard.tsx
+++ b/demo/routes/(admin)/dashboard.tsx
@@ -1,7 +1,7 @@
 import { Head } from "$fresh/runtime.ts";
 import type { Handlers, PageProps } from "$fresh/server.ts";
 
-interface Data {
+export interface Data {
   totalUsers: number;
   activeUsers: number;
 }

--- a/deno.json
+++ b/deno.json
@@ -12,9 +12,9 @@
     "preview": "deno run -A demo/main.ts"
   },
   "imports": {
-    "$fresh/": "https://deno.land/x/fresh@1.5.1/",
-    "preact": "https://esm.sh/preact@10.18.1",
-    "preact/": "https://esm.sh/preact@10.18.1/",
+    "$fresh/": "https://deno.land/x/fresh@1.6.0/",
+    "preact": "https://esm.sh/preact@10.19.2",
+    "preact/": "https://esm.sh/preact@10.19.2/",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.2.1",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.5.0",
     "twind": "https://esm.sh/twind@0.16.19",
@@ -29,9 +29,7 @@
     "$fresh-testing-library/": "./",
     "$gfm": "https://deno.land/x/gfm@0.2.5/mod.ts",
     "msw": "npm:msw@2.0.8",
-    "msw/node": "npm:msw@2.0.8/node",
-    "__TODO(#58)__": "The following line should be removed once fresh@v1.5.3 is released.",
-    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@6.2.2"
+    "msw/node": "npm:msw@2.0.8/node"
   },
   "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "preact" },
   "lint": { "rules": { "tags": ["fresh", "recommended"] } }

--- a/deps/preact-render-to-string.ts
+++ b/deps/preact-render-to-string.ts
@@ -4,6 +4,6 @@
  * TODO(uki00a): I'd like to automate the synchronization of `preact-render-to-string` versions.
  *
  * {@link https://github.com/denoland/fresh/pull/1684}
- * {@link https://github.com/denoland/fresh/blob/5de34aac93a0090d85d6cd449c413b97a98f018e/src/server/deps.ts#L23}
+ * {@link https://github.com/denoland/fresh/blob/1.6.0/src/server/deps.ts#L25}
  */
-export { render } from "https://esm.sh/*preact-render-to-string@6.2.2";
+export { render } from "https://esm.sh/*preact-render-to-string@6.3.1";

--- a/internal/fresh/config.ts
+++ b/internal/fresh/config.ts
@@ -1,0 +1,38 @@
+import { join } from "node:path";
+import type {
+  FreshConfig,
+  Manifest,
+  RenderFunction,
+  ResolvedFreshConfig,
+} from "$fresh/server.ts";
+
+const kFreshBuildDir = "_fresh";
+const kFreshStaticDir = "static";
+
+export function resolveConfig(
+  config: FreshConfig,
+  manifest?: Manifest,
+): ResolvedFreshConfig {
+  return {
+    dev: true,
+    build: {
+      outDir: manifest
+        ? join(new URL(manifest.baseUrl).pathname, kFreshBuildDir)
+        : kFreshBuildDir,
+      target: [],
+      ...config.build,
+    },
+    staticDir: config.staticDir ?? manifest
+      ? join(new URL(manifest.baseUrl).pathname, kFreshStaticDir)
+      : kFreshStaticDir,
+    plugins: config.plugins ?? [],
+    router: config.router,
+    basePath: config.router?.basePath ?? "",
+    server: config.server ?? {},
+    render: config.render ?? render,
+  };
+}
+
+const render: RenderFunction = () => {
+  throw new Error("`ResolvedFreshConfig.render` is not implemented yet.");
+};

--- a/internal/fresh/config.ts
+++ b/internal/fresh/config.ts
@@ -22,9 +22,10 @@ export function resolveConfig(
       target: [],
       ...config.build,
     },
-    staticDir: config.staticDir ?? manifest
-      ? join(new URL(manifest.baseUrl).pathname, kFreshStaticDir)
-      : kFreshStaticDir,
+    staticDir: config.staticDir ??
+      (manifest
+        ? join(new URL(manifest.baseUrl).pathname, kFreshStaticDir)
+        : kFreshStaticDir),
     plugins: config.plugins ?? [],
     router: config.router,
     basePath: config.router?.basePath ?? "",

--- a/internal/fresh/mod.ts
+++ b/internal/fresh/mod.ts
@@ -3,6 +3,7 @@ import type { ClassAttributes, VNode } from "preact";
 import { h } from "preact";
 import { render } from "../../deps/preact-render-to-string.ts";
 import type {
+  FreshContext,
   Manifest,
   MiddlewareHandler,
   PageProps,
@@ -124,23 +125,11 @@ export function isSyncRouteComponent(
 
 const kContainerElement = "div";
 export function renderSyncRouteComponent(
+  ctx: FreshContext,
   routeComponent: SyncRouteComponent,
-  request: Request,
-  routePattern: string,
-  params: PageProps["params"],
-  data: PageProps["data"],
-  state: PageProps["state"],
 ) {
-  const pageProps: PageProps = {
-    url: new URL(request.url),
-    route: routePattern,
-    params,
-    data,
-    state,
-  };
-
   // NOTE: It seems that there is a mismatch between the type definitions of `preact` and `preact-render-to-string`.
-  const vnode = h(kContainerElement, {}, h(routeComponent, pageProps)) as VNode<
+  const vnode = h(kContainerElement, {}, h(routeComponent, ctx)) as VNode<
     ClassAttributes<HTMLElement>
   >; // TODO: remove this type casting.
   const html = render(vnode);
@@ -154,7 +143,7 @@ export function renderSyncRouteComponent(
 export async function renderAsyncRouteComponent(
   routeComponent: AsyncRouteComponent,
   request: Request,
-  ctx: RouteContext,
+  ctx: FreshContext,
 ): Promise<Response> {
   const result = await routeComponent(
     request,

--- a/internal/fresh/mod.ts
+++ b/internal/fresh/mod.ts
@@ -128,10 +128,7 @@ export function renderSyncRouteComponent(
   ctx: FreshContext,
   routeComponent: SyncRouteComponent,
 ) {
-  // NOTE: It seems that there is a mismatch between the type definitions of `preact` and `preact-render-to-string`.
-  const vnode = h(kContainerElement, {}, h(routeComponent, ctx)) as VNode<
-    ClassAttributes<HTMLElement>
-  >; // TODO: remove this type casting.
+  const vnode = h(kContainerElement, {}, h(routeComponent, ctx));
   const html = render(vnode);
   return new Response(html, {
     headers: {

--- a/internal/test_utils/mod.ts
+++ b/internal/test_utils/mod.ts
@@ -1,8 +1,4 @@
-import type {
-  HandlerContext,
-  MiddlewareHandlerContext,
-  RouteContext,
-} from "$fresh/server.ts";
+import type { FreshContext, RouteContext } from "$fresh/server.ts";
 
 import { assert } from "$std/assert/assert.ts";
 import { assertEquals } from "$std/assert/assert_equals.ts";
@@ -16,7 +12,7 @@ export async function loadManifest() {
 }
 
 export function assertContextHasDefaultServerInfo(
-  ctx: HandlerContext | MiddlewareHandlerContext | RouteContext,
+  ctx: FreshContext | RouteContext,
 ) {
   assert(ctx.localAddr);
   assert(ctx.localAddr.transport === "tcp");
@@ -28,7 +24,7 @@ export function assertContextHasDefaultServerInfo(
 }
 
 export function assertContextHasServerInfoForRequest(
-  ctx: HandlerContext | MiddlewareHandlerContext | RouteContext,
+  ctx: FreshContext | RouteContext,
   req: Request,
 ) {
   const url = new URL(req.url);

--- a/routes.test.tsx
+++ b/routes.test.tsx
@@ -1,5 +1,5 @@
 import {
-  createHandlerContext,
+  createFreshContext,
   createRouteContext,
 } from "$fresh-testing-library/server.ts";
 import {
@@ -15,6 +15,7 @@ import { afterEach, beforeAll, describe, it } from "$std/testing/bdd.ts";
 import { cheerio } from "./deps/cheerio.ts";
 import { default as UserDetail } from "./demo/routes/users/[id].tsx";
 import { default as manifest } from "./demo/fresh.gen.ts";
+import type { Data } from "./demo/routes/(admin)/dashboard.tsx";
 import { handler } from "./demo/routes/(admin)/dashboard.tsx";
 import { createInMemoryUsers } from "./demo/services/users.ts";
 
@@ -25,7 +26,7 @@ describe("routes testing", () => {
   it("supports testing an async route component", async () => {
     const req = new Request("http://localhost:8000/users/2");
     const state = { users: createInMemoryUsers() };
-    const ctx = createRouteContext<void, typeof state>(req, {
+    const ctx = createFreshContext<void, typeof state>(req, {
       manifest,
       state,
     });
@@ -38,7 +39,7 @@ describe("routes testing", () => {
   it("supports testing a route component with `handler.GET`", async () => {
     // https://github.com/uki00a/fresh-testing-library/issues/38
     const request = new Request("http://localhost:8000/dashboard");
-    const ctx = createHandlerContext(
+    const ctx = createFreshContext<Data, Data>(
       request,
       {
         state: { activeUsers: 45, totalUsers: 123 },

--- a/server.test.ts
+++ b/server.test.ts
@@ -242,7 +242,7 @@ describe("$fresh-testing-library/server", () => {
   });
 
   describe("createRouteContext", () => {
-    it("returns a `RouteContext` which is a subset of a `FreshContext`", async () => {
+    it("returns a `RouteContext` which is a subset of a `FreshContext`", () => {
       function removeMethods<T extends RouteContext | FreshContext>(
         ctx: T,
       ): Record<keyof T, unknown> {

--- a/server.test.ts
+++ b/server.test.ts
@@ -52,7 +52,7 @@ describe("$fresh-testing-library/server", () => {
       ]);
     });
 
-    it("can only receive `Request`", async () => {
+    it("can receive `Request`", async () => {
       const req = new Request("http://localhost:8019");
       const ctx = createFreshContext(req);
       assertContextHasServerInfoForRequest(ctx, req);
@@ -67,7 +67,7 @@ describe("$fresh-testing-library/server", () => {
       assertEquals(res.status, 404);
     });
 
-    it("can only receive an empty object", async () => {
+    it("can receive an empty object", async () => {
       const ctx = createFreshContext({});
       assertContextHasDefaultServerInfo(ctx);
       assertEquals(ctx.params, {});

--- a/server.test.ts
+++ b/server.test.ts
@@ -1,8 +1,10 @@
 import {
+  createFreshContext,
   createHandlerContext,
   createMiddlewareHandlerContext,
   createRouteContext,
 } from "$fresh-testing-library/server.ts";
+import type { FreshContext, RouteContext } from "$fresh/server.ts";
 import { handler } from "🗺/api/users/[id].ts";
 import { createLoggerMiddleware } from "🗺/(_middlewares)/logger.ts";
 import { createInMemoryUsers } from "🔧/users.ts";
@@ -20,53 +22,93 @@ import {
 } from "./internal/test_utils/mod.ts";
 
 describe("$fresh-testing-library/server", () => {
-  describe("createHandlerContext", () => {
-    it("returns `HandlerContext` which can be passed to fresh handlers", async () => {
+  describe("createFreshContext", () => {
+    it("returns `FreshContext` which can be passed to fresh handlers", async () => {
       assert(handler.GET);
 
       const req = new Request("http://localhost:3000/api/users/1");
-      const ctx = createHandlerContext(req, { params: { id: "1" } });
+      const ctx = createFreshContext(req, { params: { id: "1" } });
       const res = await handler.GET(req, ctx);
       assertEquals(res.status, 200);
       assertEquals(await res.text(), "bob");
     });
 
-    it("can accept `Request`", () => {
+    it("returns `FreshContext` which can be passed to fresh middlewares", async () => {
+      const messages: Array<string> = [];
+      const testingLogger = {
+        info(...args: Array<unknown>) {
+          messages.push(args.map(String).join(""));
+        },
+      };
+      const middleware = createLoggerMiddleware(testingLogger);
+      const manifest = await loadManifest();
+      const path = `/api/users/123`;
+      const req = new Request(`http://localhost:3000${path}`);
+      const ctx = createFreshContext(req, { manifest });
+      await middleware(req, ctx);
+      assertEquals(messages, [
+        `<-- GET ${path}`,
+        `--> GET ${path} 200`,
+      ]);
+    });
+
+    it("can only receive `Request`", async () => {
       const req = new Request("http://localhost:8019");
-      const ctx = createHandlerContext(req);
+      const ctx = createFreshContext(req);
       assertContextHasServerInfoForRequest(ctx, req);
       assertEquals(ctx.params, {});
       assertEquals(ctx.state, {});
+      assertEquals(ctx.route, "/");
+      assertEquals(ctx.data, {});
+      assertEquals(ctx.url.href, "http://localhost:8019/");
+      assertEquals(ctx.destination, "notFound");
+
+      const res = await ctx.renderNotFound();
+      assertEquals(res.status, 404);
     });
 
-    it("can accept an empty object", async () => {
-      const ctx = createHandlerContext({});
+    it("can only receive an empty object", async () => {
+      const ctx = createFreshContext({});
       assertContextHasDefaultServerInfo(ctx);
       assertEquals(ctx.params, {});
       assertEquals(ctx.state, {});
+      assertEquals(ctx.route, "/");
+      assertEquals(ctx.data, {});
+      assertEquals(ctx.url.href, "http://localhost:8020/");
+      assertEquals(ctx.destination, "notFound");
 
       const res = await ctx.render();
       await assertDefaultResponseAsync(res);
 
       const resNotFound = await ctx.renderNotFound();
       assertEquals(resNotFound.status, 404);
+
+      const res2 = await ctx.next();
+      await assertDefaultResponseAsync(res2);
     });
 
     it("works with no arguments", async () => {
-      const ctx = createHandlerContext();
+      const ctx = createFreshContext();
       assertContextHasDefaultServerInfo(ctx);
       assertEquals(ctx.params, {});
       assertEquals(ctx.state, {});
+      assertEquals(ctx.route, "/");
+      assertEquals(ctx.data, {});
+      assertEquals(ctx.url.href, "http://localhost:8020/");
+      assertEquals(ctx.destination, "notFound");
 
       const res = await ctx.render();
       await assertDefaultResponseAsync(res);
 
       const resNotFound = await ctx.renderNotFound();
       assertEquals(resNotFound.status, 404);
+
+      const res2 = await ctx.next();
+      await assertDefaultResponseAsync(res2);
     });
 
-    it("can accept `CreateHandlerContextOptions`", async () => {
-      const ctx = createHandlerContext({
+    it("can accept `CreateFreshContextOptions`", async () => {
+      const ctx = createFreshContext({
         localAddr: {
           transport: "tcp",
           hostname: "127.0.0.1",
@@ -79,10 +121,12 @@ describe("$fresh-testing-library/server", () => {
         },
         params: { id: "123" },
         state: { foo: "bar" },
+        data: { name: "foo" },
         response: new Response("foobar"),
         responseNotFound: new Response("This page is not found.", {
           status: 404,
         }),
+        destination: "static",
       });
       assert(ctx.localAddr);
       assert(ctx.localAddr.transport === "tcp");
@@ -93,6 +137,10 @@ describe("$fresh-testing-library/server", () => {
       assertEquals(ctx.remoteAddr.port, 50000);
       assertEquals(ctx.params, { id: "123" });
       assertEquals(ctx.state, { foo: "bar" });
+      assertEquals(ctx.data, { name: "foo" });
+      assertEquals(ctx.route, "/");
+      assertEquals(ctx.url.href, "http://127.0.0.1:3000/");
+      assertEquals(ctx.destination, "static");
 
       const res = await ctx.render();
       assertEquals(res.status, 200);
@@ -101,13 +149,19 @@ describe("$fresh-testing-library/server", () => {
       const resNotFound = await ctx.renderNotFound();
       assertEquals(resNotFound.status, 404);
       assertEquals(await resNotFound.text(), "This page is not found.");
+
+      const res2 = await ctx.next();
+      assertEquals(res2.status, 200);
+      assertEquals(await res2.text(), "foobar");
     });
 
-    it("can accept both `Request` and `CreateHandlerContextOptions`", async () => {
+    it("can accept both `Request` and `CreateFreshContextOptions`", async () => {
       const req = new Request("http://localhost:8020/users/5678");
-      const ctx = createHandlerContext(req, {
+      const ctx = createFreshContext(req, {
         params: { id: "5678" },
         state: { key: "value" },
+        data: { user: "barbaz" },
+        destination: "route",
         response: () => Promise.resolve(new Response("OK")),
         responseNotFound: () =>
           Promise.resolve(
@@ -119,6 +173,10 @@ describe("$fresh-testing-library/server", () => {
       assertContextHasServerInfoForRequest(ctx, req);
       assertEquals(ctx.params, { id: "5678" });
       assertEquals(ctx.state, { key: "value" });
+      assertEquals(ctx.data, { user: "barbaz" });
+      assertEquals(ctx.route, "/");
+      assertEquals(ctx.url.href, "http://localhost:8020/users/5678");
+      assertEquals(ctx.destination, "route");
 
       const res = await ctx.render();
       await assertDefaultResponseAsync(res);
@@ -126,32 +184,41 @@ describe("$fresh-testing-library/server", () => {
       const resNotFound = await ctx.renderNotFound();
       assertEquals(resNotFound.status, 404);
       assertEquals(await resNotFound.text(), "NotFound");
+
+      const res2 = await ctx.next();
+      await assertDefaultResponseAsync(res2);
     });
 
-    it("can extract params from `Request` based on `manifest` option", async () => {
+    it("can infer `params` and `destination` from `Request` based on `manifest` option", async () => {
       const manifest = await loadManifest();
 
       {
         const req = new Request("http://localhost:8002/api/users/123");
-        const ctx = createHandlerContext(req, { manifest });
+        const ctx = createFreshContext(req, { manifest });
         assertEquals(ctx.params, { id: "123" });
         assertEquals(ctx.state, {});
+        assertEquals(ctx.route, "/api/users/:id");
+        assertEquals(ctx.destination, "route");
         assertContextHasServerInfoForRequest(ctx, req);
       }
 
       {
         const req = new Request("https://localhost:8000/api/users/123");
-        const ctx = createHandlerContext(req, {
+        const ctx = createFreshContext(req, {
           manifest,
           params: { id: "9876" },
         });
         assertEquals(ctx.params, { id: "9876" });
+        assertEquals(ctx.route, "/api/users/:id");
+        assertEquals(ctx.destination, "route");
       }
 
       {
         const req = new Request("https://localhost:8000/no/such/route");
-        const ctx = createHandlerContext(req, { manifest });
+        const ctx = createFreshContext(req, { manifest });
         assertEquals(ctx.params, {});
+        assertEquals(ctx.route, "/");
+        assertEquals(ctx.destination, "notFound");
       }
     });
 
@@ -159,7 +226,7 @@ describe("$fresh-testing-library/server", () => {
       const manifest = await loadManifest();
       const req = new Request("http://localhost:8003/users/1");
       const state = { users: createInMemoryUsers() };
-      const ctx = createHandlerContext(req, { manifest, state });
+      const ctx = createFreshContext(req, { manifest, state });
       const res = await ctx.render();
       assertEquals(res.status, 200);
       assertEquals(res.headers.get("Content-Type"), "text/html; charset=UTF-8");
@@ -175,262 +242,33 @@ describe("$fresh-testing-library/server", () => {
   });
 
   describe("createRouteContext", () => {
-    it("can accept `Request`", async () => {
-      const req = new Request("http://localhost:8006");
-      const ctx = createRouteContext(req);
-      assertContextHasServerInfoForRequest(ctx, req);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.state, {});
-      assertEquals(ctx.route, "/");
-      assertEquals(ctx.data, undefined);
-      assertEquals(ctx.url.href, "http://localhost:8006/");
-
-      const res = await ctx.renderNotFound();
-      assertEquals(res.status, 404);
-    });
-
-    it("can accept an empty object", async () => {
-      const ctx = createRouteContext({});
-      assertContextHasDefaultServerInfo(ctx);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.state, {});
-      assertEquals(ctx.route, "/");
-      assertEquals(ctx.data, undefined);
-      assertEquals(ctx.url.href, "http://localhost:8020/");
-
-      const res = await ctx.renderNotFound();
-      assertEquals(res.status, 404);
-    });
-
-    it("works with no arguments", async () => {
-      const ctx = createRouteContext();
-      assertContextHasDefaultServerInfo(ctx);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.state, {});
-      assertEquals(ctx.route, "/");
-      assertEquals(ctx.data, undefined);
-      assertEquals(ctx.url.href, "http://localhost:8020/");
-
-      const res = await ctx.renderNotFound();
-      assertEquals(res.status, 404);
-    });
-
-    it("can accept `CreateRouteContextOptions`", async () => {
-      const now = Date.now();
-      const ctx = createRouteContext({
-        localAddr: {
-          transport: "tcp",
-          hostname: "127.0.0.1",
-          port: 3002,
-        },
-        remoteAddr: {
-          transport: "tcp",
-          hostname: "localhost",
-          port: 50002,
-        },
-        params: { id: "1234567" },
-        state: { now },
-        data: { name: "foo" },
-        responseNotFound: new Response("No such route", { status: 404 }),
-      });
-      assert(ctx.localAddr);
-      assert(ctx.localAddr.transport === "tcp");
-      assertEquals(ctx.localAddr.hostname, "127.0.0.1");
-      assertEquals(ctx.localAddr.port, 3002);
-      assert(ctx.remoteAddr.transport === "tcp");
-      assertEquals(ctx.remoteAddr.hostname, "localhost");
-      assertEquals(ctx.remoteAddr.port, 50002);
-      assertEquals(ctx.params, { id: "1234567" });
-      assertEquals(ctx.state, { now });
-      assertEquals(ctx.data, { name: "foo" });
-      assertEquals(ctx.route, "/");
-      assertEquals(ctx.url.href, "http://127.0.0.1:3002/");
-
-      const res = await ctx.renderNotFound();
-      assertEquals(res.status, 404);
-      assertEquals(await res.text(), "No such route");
-    });
-
-    it("can accept both `Request` and `CreateRouteContextOptions`", async () => {
-      const now = Date.now();
-      const req = new Request("http://localhost:8022/items/5432");
-      const ctx = createRouteContext(req, {
-        params: { itemID: "5432" },
-        state: { now },
-        data: { item: "barbaz" },
-      });
-      assertContextHasServerInfoForRequest(ctx, req);
-      assertEquals(ctx.params, { itemID: "5432" });
-      assertEquals(ctx.state, { now });
-      assertEquals(ctx.data, { item: "barbaz" });
-      assertEquals(ctx.route, "/");
-      assertEquals(ctx.url.href, "http://localhost:8022/items/5432");
-
-      const res = await ctx.renderNotFound();
-      assertEquals(res.status, 404);
-    });
-
-    it("can extract params from `Request` and infer `route` based on `manifest` option", async () => {
-      const manifest = await loadManifest();
-
-      {
-        const req = new Request("http://localhost:8007/api/users/9999");
-        const ctx = createRouteContext(req, { manifest });
-        assertEquals(ctx.params, { id: "9999" });
-        assertEquals(ctx.state, {});
-        assertEquals(ctx.route, "/api/users/:id");
-        assertContextHasServerInfoForRequest(ctx, req);
+    it("returns a `RouteContext` which is a subset of a `FreshContext`", async () => {
+      function removeMethods<T extends RouteContext | FreshContext>(
+        ctx: T,
+      ): Record<keyof T, unknown> {
+        const result = {} as Record<keyof T, unknown>;
+        for (const key in ctx) {
+          if (typeof ctx[key] !== "function") {
+            result[key] = ctx[key];
+          }
+        }
+        return result;
       }
+      const routeCtx = createRouteContext();
+      const freshCtx = createFreshContext();
+      assertEquals(removeMethods(routeCtx), removeMethods(freshCtx));
+    });
+  });
 
-      {
-        const req = new Request("https://localhost:8008/api/users/879");
-        const ctx = createRouteContext(req, {
-          manifest,
-          params: { id: "123456" },
-        });
-        assertEquals(ctx.params, { id: "123456" });
-        assertEquals(ctx.route, "/api/users/:id");
-      }
-
-      {
-        const req = new Request("https://localhost:8009/no/such/route");
-        const ctx = createRouteContext(req, { manifest });
-        assertEquals(ctx.params, {});
-        assertEquals(ctx.route, "/");
-      }
+  describe("createHandlerContext", () => {
+    it("is an alias of `createFreshContext`", () => {
+      assertEquals(createHandlerContext, createFreshContext);
     });
   });
 
   describe("createMiddlewareHandlerContext", () => {
-    it("returns `MiddlwareHandlerContext` which can be passed to fresh middlewares", async () => {
-      const messages: Array<string> = [];
-      const testingLogger = {
-        info(...args: Array<unknown>) {
-          messages.push(args.map(String).join(""));
-        },
-      };
-      const middleware = createLoggerMiddleware(testingLogger);
-      const manifest = await loadManifest();
-      const path = `/api/users/123`;
-      const req = new Request(`http://localhost:3000${path}`);
-      const ctx = createMiddlewareHandlerContext(req, { manifest });
-      await middleware(req, ctx);
-      assertEquals(messages, [
-        `<-- GET ${path}`,
-        `--> GET ${path} 200`,
-      ]);
-    });
-
-    it("can accept `Request`", () => {
-      const req = new Request("http://localhost:8019");
-      const ctx = createMiddlewareHandlerContext(req);
-      assertContextHasServerInfoForRequest(ctx, req);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.state, {});
-      assertEquals(ctx.destination, "notFound");
-    });
-
-    it("can accept an empty object", async () => {
-      const ctx = createMiddlewareHandlerContext({});
-      assertContextHasDefaultServerInfo(ctx);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.state, {});
-      assertEquals(ctx.destination, "notFound");
-
-      const res = await ctx.next();
-      await assertDefaultResponseAsync(res);
-    });
-
-    it("works with no arguments", async () => {
-      const ctx = createMiddlewareHandlerContext();
-      assertContextHasDefaultServerInfo(ctx);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.state, {});
-      assertEquals(ctx.destination, "notFound");
-
-      const res = await ctx.next();
-      await assertDefaultResponseAsync(res);
-    });
-
-    it("can accept `CreateMiddlewareHandlerContextOptions`", async () => {
-      const ctx = createMiddlewareHandlerContext({
-        localAddr: {
-          transport: "tcp",
-          hostname: "127.0.0.1",
-          port: 3001,
-        },
-        remoteAddr: {
-          transport: "tcp",
-          hostname: "localhost",
-          port: 50001,
-        },
-        params: { filename: "test.txt" },
-        state: { user: "foobar" },
-        response: new Response("testing"),
-        destination: "static",
-      });
-      assert(ctx.localAddr);
-      assert(ctx.localAddr.transport === "tcp");
-      assertEquals(ctx.localAddr.hostname, "127.0.0.1");
-      assertEquals(ctx.localAddr.port, 3001);
-      assert(ctx.remoteAddr.transport === "tcp");
-      assertEquals(ctx.remoteAddr.hostname, "localhost");
-      assertEquals(ctx.remoteAddr.port, 50001);
-      assertEquals(ctx.params, { filename: "test.txt" });
-      assertEquals(ctx.state, { user: "foobar" });
-      assertEquals(ctx.destination, "static");
-
-      const res = await ctx.next();
-      assertEquals(res.status, 200);
-      assertEquals(await res.text(), "testing");
-    });
-
-    it("can accept both `Request` and `CreateMiddlewareHandlerContextOptions`", async () => {
-      const req = new Request("http://localhost:8021/books/924");
-      const ctx = createMiddlewareHandlerContext(req, {
-        params: { id: "924" },
-        state: { num: 12345 },
-        response: new Response("dummy response"),
-        destination: "route",
-      });
-      assertContextHasServerInfoForRequest(ctx, req);
-      assertEquals(ctx.params, { id: "924" });
-      assertEquals(ctx.state, { num: 12345 });
-      assertEquals(ctx.destination, "route");
-
-      const res = await ctx.next();
-      assertEquals(res.status, 200);
-      assertEquals(await res.text(), "dummy response");
-    });
-
-    it("can extract params from `Request` and infer `destination` based on `manifest` option", async () => {
-      const manifest = await loadManifest();
-
-      {
-        const req = new Request("http://localhost:8003/api/users/9999");
-        const ctx = createMiddlewareHandlerContext(req, { manifest });
-        assertEquals(ctx.params, { id: "9999" });
-        assertEquals(ctx.state, {});
-        assertEquals(ctx.destination, "route");
-        assertContextHasServerInfoForRequest(ctx, req);
-      }
-
-      {
-        const req = new Request("https://localhost:8004/api/users/879");
-        const ctx = createMiddlewareHandlerContext(req, {
-          manifest,
-          params: { id: "123456" },
-        });
-        assertEquals(ctx.params, { id: "123456" });
-        assertEquals(ctx.destination, "route");
-      }
-
-      {
-        const req = new Request("https://localhost:8005/no/such/route");
-        const ctx = createMiddlewareHandlerContext(req, { manifest });
-        assertEquals(ctx.params, {});
-        assertEquals(ctx.destination, "notFound");
-      }
+    it("is an alias of `createFreshContext`", () => {
+      assertEquals(createMiddlewareHandlerContext, createFreshContext);
     });
   });
 });

--- a/server.ts
+++ b/server.ts
@@ -31,7 +31,7 @@ export interface CreateFreshContextOptions<
   TState = Record<string, unknown>,
 > {
   /**
-   * @description This option allows overriding `ctx.params` property.
+   * @description This option allows overriding {@linkcode FreshContext.params} property.
    */
   params: Record<string, string>;
 

--- a/server.ts
+++ b/server.ts
@@ -36,12 +36,12 @@ export interface CreateFreshContextOptions<
   params: Record<string, string>;
 
   /**
-   * @description This option allows injecting dependencies into `ctx.state`.
+   * @description This option allows injecting dependencies into {@linkcode FreshContext.state}.
    */
   state: TState;
 
   /**
-   * @description Optionally, the {@linkcode Manifest} object which is exported from `fresh.gen.ts` can be set to this option. If this option is specified, some properties, such as {@linkcode FreshContext.params}, is automatically inferred from {@linkcode Request.url}.
+   * @description Optionally, the {@linkcode Manifest} object which is exported from `fresh.gen.ts` can be set to this option. If this option is specified, some properties, such as {@linkcode FreshContext.params}, are automatically inferred from {@linkcode Request.url}.
    */
   manifest: Manifest;
 
@@ -51,12 +51,12 @@ export interface CreateFreshContextOptions<
   config: FreshConfig;
 
   /**
-   * @description This options allows overriding `ctx.localAddr`. If not specified, `ctx.localAddr` is automatically inferred from {@linkcode Request.url}.
+   * @description This options allows overriding {@linkcode FreshContext.localAddr}. If not specified, {@linkcode FreshContext.localAddr} is automatically inferred from {@linkcode Request.url}.
    */
   localAddr: Deno.NetAddr;
 
   /**
-   * @description This options allows overriding `ctx.remoteAddr`.
+   * @description This options allows overriding {@linkcode FreshContext.remoteAddr}.
    */
   remoteAddr: Deno.NetAddr;
 

--- a/server.ts
+++ b/server.ts
@@ -22,6 +22,9 @@ import {
 } from "./internal/fresh/mod.ts";
 import { resolveConfig } from "./internal/fresh/config.ts";
 
+/**
+ * Options which can be passed to {@linkcode createFreshContext}.
+ */
 export interface CreateFreshContextOptions<
   // deno-lint-ignore no-explicit-any
   TData = any,
@@ -38,9 +41,14 @@ export interface CreateFreshContextOptions<
   state: TState;
 
   /**
-   * @description Optionally, the {@linkcode Manifest} object which is exported from `fresh.gen.ts` can be set to this option. If this option is specified, some properties, such as `ctx.params`, is automatically inferred from {@linkcode Request.url}.
+   * @description Optionally, the {@linkcode Manifest} object which is exported from `fresh.gen.ts` can be set to this option. If this option is specified, some properties, such as {@linkcode FreshContext.params}, is automatically inferred from {@linkcode Request.url}.
    */
   manifest: Manifest;
+
+  /**
+   * @description Optionally, {@linkcode FreshConfig} object which is exported from `fresh.config.ts` can be set to this option. With this option, you can test the behavior that depends on {@linkcode FreshContext.config}.
+   */
+  config: FreshConfig;
 
   /**
    * @description This options allows overriding `ctx.localAddr`. If not specified, `ctx.localAddr` is automatically inferred from {@linkcode Request.url}.
@@ -71,11 +79,6 @@ export interface CreateFreshContextOptions<
    * @description This option allows overriding {@linkcode FreshContext.destination} which is automatically inferred from {@linkcode Manifest} and {@linkcode Request.url} by default.
    */
   destination: FreshContext["destination"];
-
-  /**
-   * @description If you want to test behavior depending on {@linkcode FreshContext.config}, set the configuration object exported from `fresh.config.ts`.
-   */
-  config: FreshConfig;
 }
 
 /**

--- a/testdata/permissions/server.ts
+++ b/testdata/permissions/server.ts
@@ -1,9 +1,7 @@
 import {
-  createHandlerContext,
-  createMiddlewareHandlerContext,
+  createFreshContext,
   createRouteContext,
 } from "$fresh-testing-library/server.ts";
 
-createHandlerContext();
-createMiddlewareHandlerContext();
+createFreshContext();
 createRouteContext();


### PR DESCRIPTION
- deps: `fresh@1.6.0`, `preact-render-to-string@6.3.1`
- feat: add `createFreshContext()`
- BREAKING: deprecate `createHandlerContext` & `createMiddlewareHandlerContext`

---

Closes #66